### PR TITLE
Prevent Future-Dated Content Deploy Surprises

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,9 @@ jobs:
           hugo-version: '0.157.0'
           extended: true
 
+      - name: Guard against future-dated published content
+        run: bash scripts/check-future-content.sh
+
       - name: Cache Hugo resources
         uses: actions/cache@v5
         with:

--- a/.specs/070-future-content-deploy-guard.md
+++ b/.specs/070-future-content-deploy-guard.md
@@ -1,0 +1,41 @@
+# 070: Prevent Future-Dated Content Deploy Surprises
+
+**Branch**: `codex/future-content-deploy-guard`
+**Created**: 2026-04-08
+
+## Summary
+
+Prevent photo uploads and manual content changes from silently disappearing after deploy when Hugo treats them as future content. The fix should make uploader dates explicit and site-timezone-aware, and it should make CI fail fast when `main` contains published pages that Cloudflare Pages will not render yet.
+
+## Requirements
+
+- Late-evening uploads must not default to the next UTC day when the site timezone is still the previous day.
+- The photo upload flow must show the effective publish date before submission and prevent obviously future-dated publishes to `main`.
+- PR and push CI must fail with a clear message when non-draft future content exists anywhere the site build would omit it.
+- The validation must protect manual content edits and scripted uploads, not only the browser uploader.
+- The solution must not globally enable future-content builds; intentionally scheduled content should stay an explicit workflow decision instead of publishing early by accident.
+
+## Design
+
+Use a two-layer guard. First, update the uploader to compute dates in the site timezone (`America/New_York`) instead of UTC, prefill an editable date field from EXIF or the site-local current day, and block submit when the chosen date is in the future for the site timezone. Second, add a CI validation step before deploy that runs Hugo's future-content listing and fails if any published page would be excluded from the build. This keeps the deploy semantics aligned with Hugo instead of reimplementing date parsing.
+
+Do not switch the Pages build to `--buildFuture`. That would hide the problem by publishing content early, and it still would not create a true scheduled-publishing system because Cloudflare Pages does not rebuild itself at midnight. If scheduled publishing is needed later, handle it as a separate automation or publish-date workflow.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `static/upload/index.html` | Add an explicit publish date control and inline validation/help text in the uploader UI |
+| `static/upload/app.js` | Replace the UTC date fallback with site-timezone date logic, prefill and validate the date field, and block future-dated auto-merge uploads |
+| `scripts/check-future-content.sh` | Wrap `hugo list future` with actionable failure output for CI and local verification |
+| `.github/workflows/deploy.yml` | Run the future-content validation before the build and deploy steps on PRs and `main` pushes |
+| `README.md` | Document that future-dated published content is rejected because static deploys do not auto-publish at midnight |
+
+## Test Plan
+
+- [x] Uploading a photo without EXIF after 8 PM ET uses the ET calendar date, not the next UTC day
+- [x] The upload UI surfaces the publish date and blocks submission when that date would be future content in the site timezone
+- [x] `scripts/check-future-content.sh` passes for normal content and fails with a clear error for a temporary future-dated test page
+- [ ] The next successful deploy includes the previously missed bonsai photo in `/photography/`
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [x] Site renders correctly on localhost (`hugo server -D`)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Personal website of **Matt Walker** — software engineer, data & AI practitione
 
 **AI-Powered Descriptions** — Uploaded photos are automatically described by [Claude](https://www.anthropic.com/) Haiku vision model — generating titles, alt text, and personalized descriptions. Review the AI output, tweak it, regenerate, and publish.
 
+**Publish Date Guardrails** - The upload flow writes publish dates in `America/New_York`, and deploy CI fails if published content is still in the future because Cloudflare Pages will not auto-publish it at midnight.
+
 See the full stack breakdown at **[mrmatt.io/stack](https://mrmatt.io/stack)**
 
 ## License

--- a/scripts/check-future-content.sh
+++ b/scripts/check-future-content.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+tmp_output="$(mktemp)"
+cleanup() {
+  rm -f "$tmp_output"
+}
+trap cleanup EXIT
+
+HUGO_BIN="${HUGO_BIN:-$(command -v hugo || true)}"
+if [[ -z "$HUGO_BIN" ]]; then
+  printf 'Error: hugo was not found on PATH. Set HUGO_BIN to your Hugo executable when running locally.\n' >&2
+  exit 127
+fi
+
+"$HUGO_BIN" list future "$@" >"$tmp_output"
+
+future_paths=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] || continue
+  [[ "$line" == path,* ]] && continue
+
+  path="${line%%,*}"
+  [[ -n "$path" ]] || continue
+
+  if [[ -f "$path" ]] && head -n 40 "$path" | grep -Eqi '^[[:space:]]*draft[[:space:]]*[:=][[:space:]]*true([[:space:]]|$)'; then
+    continue
+  fi
+
+  future_paths+=("$path")
+done <"$tmp_output"
+
+if ((${#future_paths[@]})); then
+  printf 'Error: Hugo found future-dated published content that would be omitted from deploy:\n' >&2
+  for path in "${future_paths[@]}"; do
+    printf '  - %s\n' "$path" >&2
+  done
+  printf '\n' >&2
+  printf 'Static deploys do not automatically rebuild when midnight arrives.\n' >&2
+  printf 'Use today'"'"'s site-local date, mark the content as draft, or publish it in a later deploy.\n' >&2
+  exit 1
+fi
+
+printf 'No future-dated published content detected.\n'

--- a/static/upload/app.js
+++ b/static/upload/app.js
@@ -5,6 +5,13 @@
     var REPO_NAME = 'MrMatt.io';
     var BRANCH = 'main';
     var ALLOWED_USER = 'MrMatt57';
+    var SITE_TIME_ZONE = 'America/New_York';
+    var SITE_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+        timeZone: SITE_TIME_ZONE,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit'
+    });
 
     var statusEl = document.getElementById('status');
     var authSection = document.getElementById('auth-section');
@@ -18,6 +25,8 @@
     var userInfo = document.getElementById('user-info');
     var aiStatus = document.getElementById('ai-status');
     var aiTitle = document.getElementById('ai-title');
+    var publishDateInput = document.getElementById('publish-date');
+    var publishDateStatus = document.getElementById('publish-date-status');
     var aiAlt = document.getElementById('ai-alt');
     var aiDesc = document.getElementById('ai-description');
     var aiSection = document.getElementById('ai-section');
@@ -25,6 +34,7 @@
     var regenerateBtn = document.getElementById('regenerate-btn');
 
     var currentPhotoFile = null;
+    var publishDateRequestId = 0;
 
     // --- Escape a string for use inside YAML double-quoted values ---
     function escapeYamlString(str) {
@@ -41,6 +51,97 @@
 
     function getFileStem(name) {
         return (name || '').replace(/\.[^.]+$/, '');
+    }
+
+    function getSiteLocalDateString(date) {
+        var parts = SITE_DATE_FORMATTER.formatToParts(date);
+        var year = '';
+        var month = '';
+        var day = '';
+
+        parts.forEach(function(part) {
+            if (part.type === 'year') {
+                year = part.value;
+            } else if (part.type === 'month') {
+                month = part.value;
+            } else if (part.type === 'day') {
+                day = part.value;
+            }
+        });
+
+        return year + '-' + month + '-' + day;
+    }
+
+    function setPublishDateStatus(message, type) {
+        publishDateStatus.textContent = message;
+        publishDateStatus.className = 'field-help' + (type ? ' ' + type : '');
+    }
+
+    function setPublishDateValue(dateStr, source) {
+        publishDateInput.value = dateStr;
+        publishDateInput.dataset.source = source || 'manual';
+        validatePublishDate();
+    }
+
+    function validatePublishDate() {
+        var siteToday = getSiteLocalDateString(new Date());
+        var dateStr = publishDateInput.value;
+        var source = publishDateInput.dataset.source || 'manual';
+        var message = '';
+
+        publishDateInput.max = siteToday;
+
+        if (!dateStr) {
+            publishDateInput.classList.add('invalid');
+            setPublishDateStatus('Choose a publish date in ' + SITE_TIME_ZONE + ' before uploading.', 'error');
+            return { valid: false, dateStr: '' };
+        }
+
+        if (dateStr > siteToday) {
+            publishDateInput.classList.add('invalid');
+            setPublishDateStatus('This date is in the future for ' + SITE_TIME_ZONE + ' and Hugo would skip it during deploy. Pick today or earlier.', 'error');
+            return { valid: false, dateStr: dateStr };
+        }
+
+        publishDateInput.classList.remove('invalid');
+        if (source === 'exif') {
+            message = 'Using EXIF date ' + dateStr + ' in ' + SITE_TIME_ZONE + '.';
+        } else if (source === 'site-local') {
+            message = 'Using the site-local date ' + dateStr + ' in ' + SITE_TIME_ZONE + '.';
+        } else {
+            message = 'Publish date will be saved as ' + dateStr + ' in ' + SITE_TIME_ZONE + '.';
+        }
+        setPublishDateStatus(message + ' Future dates are rejected because Cloudflare Pages does not auto-publish at midnight.', 'info');
+
+        return { valid: true, dateStr: dateStr };
+    }
+
+    function prefillPublishDate(fileOrBlob) {
+        var requestId = ++publishDateRequestId;
+        publishDateInput.max = getSiteLocalDateString(new Date());
+        return extractExifDate(fileOrBlob).then(function(exifDate) {
+            if (requestId !== publishDateRequestId) {
+                return;
+            }
+            setPublishDateValue(exifDate || getSiteLocalDateString(new Date()), exifDate ? 'exif' : 'site-local');
+        });
+    }
+
+    function clearUploadForm() {
+        publishDateRequestId += 1;
+        photoInput.value = '';
+        previewEl.classList.remove('visible');
+        aiSection.style.display = 'none';
+        window._sharedPhoto = null;
+        currentPhotoFile = null;
+        aiFeedback.value = '';
+        aiTitle.value = '';
+        publishDateInput.value = '';
+        publishDateInput.dataset.source = 'manual';
+        publishDateInput.classList.remove('invalid');
+        setPublishDateStatus('Publish date uses ' + SITE_TIME_ZONE + '. Future dates are rejected because Cloudflare Pages does not auto-publish at midnight.', 'info');
+        aiAlt.value = '';
+        aiDesc.value = '';
     }
 
     // --- Extract EXIF date from JPEG ---
@@ -263,7 +364,7 @@
             caches.delete('shared-photos');
             window.history.replaceState({}, '', '/upload/');
 
-            // Auto-describe shared photo
+            prefillPublishDate(blob);
             describePhoto(blob);
         });
     }
@@ -382,7 +483,13 @@
         }
         previewEl.classList.add('visible');
         aiFeedback.value = '';
+        prefillPublishDate(file);
         describePhoto(file);
+    });
+
+    publishDateInput.addEventListener('input', function() {
+        publishDateInput.dataset.source = 'manual';
+        validatePublishDate();
     });
 
     // --- Regenerate AI description with feedback ---
@@ -396,6 +503,7 @@
         clearToken();
         showLoginForm();
         hideStatus();
+        clearUploadForm();
     });
 
     // --- GitHub API helpers ---
@@ -541,6 +649,12 @@
             return;
         }
 
+        var publishDate = validatePublishDate();
+        if (!publishDate.valid) {
+            showStatus('Pick a publish date that is today or earlier in ' + SITE_TIME_ZONE + '.', 'error');
+            return;
+        }
+
         var token = getToken();
         if (!token) {
             showStatus('Please log in first.', 'error');
@@ -553,85 +667,74 @@
         var title = aiTitle.value.trim();
         var alt = aiAlt.value.trim();
         var description = aiDesc.value.trim();
+        var dateStr = publishDate.dateStr;
+        var slug = slugify(title) || slugify(getFileStem(file.name)) || 'photo';
 
-        extractExifDate(file).then(function(exifDate) {
-            var now = new Date();
-            var dateStr = exifDate || now.toISOString().slice(0, 10);
-            var slug = slugify(title) || slugify(getFileStem(file.name)) || 'photo';
+        var reader = new FileReader();
+        reader.onload = function() {
+            var base64 = reader.result.split(',')[1];
+            var ext = file.type === 'image/png' ? 'png' : file.type === 'image/webp' ? 'webp' : 'jpg';
+            var pageTitle = title || 'Photo ' + dateStr;
+            var frontMatter = '---\n' +
+                'title: "' + escapeYamlString(pageTitle) + '"\n' +
+                'date: "' + dateStr + '"\n';
+            if (alt) {
+                frontMatter += 'alt: "' + escapeYamlString(alt) + '"\n';
+            }
+            if (description) {
+                frontMatter += 'description: "' + escapeYamlString(description) + '"\n';
+            }
+            frontMatter += 'draft: false\n---\n';
 
-            var reader = new FileReader();
-            reader.onload = function() {
-                var base64 = reader.result.split(',')[1];
-                var ext = file.type === 'image/png' ? 'png' : file.type === 'image/webp' ? 'webp' : 'jpg';
-                var pageTitle = title || 'Photo ' + dateStr;
-                var frontMatter = '---\n' +
-                    'title: "' + escapeYamlString(pageTitle) + '"\n' +
-                    'date: "' + dateStr + '"\n';
-                if (alt) {
-                    frontMatter += 'alt: "' + escapeYamlString(alt) + '"\n';
-                }
-                if (description) {
-                    frontMatter += 'description: "' + escapeYamlString(description) + '"\n';
-                }
-                frontMatter += 'draft: false\n---\n';
-
-                showStatus('Creating branch...', 'info');
-                Promise.all([
-                    getMainSha(token),
-                    findAvailableUploadTarget(token, dateStr, slug)
-                ])
-                    .then(function(results) {
-                        var sha = results[0];
-                        var target = results[1];
-                        return createBranch(token, target.branchName, sha).then(function() {
-                            return target;
-                        });
-                    })
-                    .then(function(target) {
-                        showStatus('Uploading photo...', 'info');
-                        return commitFile(
-                            token,
-                            target.basePath + '/photo.' + ext,
-                            base64,
-                            'feat: add photo ' + target.folderName,
-                            target.branchName
-                        ).then(function() {
-                            return target;
-                        });
-                    })
-                    .then(function(target) {
-                        showStatus('Saving metadata...', 'info');
-                        return commitFile(
-                            token,
-                            target.basePath + '/index.md',
-                            btoa(unescape(encodeURIComponent(frontMatter))),
-                            'feat: add photo metadata ' + target.folderName,
-                            target.branchName
-                        ).then(function() {
-                            return target;
-                        });
-                    })
-                    .then(function(target) {
-                        showStatus('Creating pull request...', 'info');
-                        return createPR(token, 'feat: add photo ' + target.folderName, target.branchName, BRANCH);
-                    })
-                    .then(function(pr) {
-                        return enableAutoMerge(token, pr.node_id).then(function() {
-                            return pr;
-                        });
-                    })
+            showStatus('Creating branch...', 'info');
+            Promise.all([
+                getMainSha(token),
+                findAvailableUploadTarget(token, dateStr, slug)
+            ])
+                .then(function(results) {
+                    var sha = results[0];
+                    var target = results[1];
+                    return createBranch(token, target.branchName, sha).then(function() {
+                        return target;
+                    });
+                })
+                .then(function(target) {
+                    showStatus('Uploading photo...', 'info');
+                    return commitFile(
+                        token,
+                        target.basePath + '/photo.' + ext,
+                        base64,
+                        'feat: add photo ' + target.folderName,
+                        target.branchName
+                    ).then(function() {
+                        return target;
+                    });
+                })
+                .then(function(target) {
+                    showStatus('Saving metadata...', 'info');
+                    return commitFile(
+                        token,
+                        target.basePath + '/index.md',
+                        btoa(unescape(encodeURIComponent(frontMatter))),
+                        'feat: add photo metadata ' + target.folderName,
+                        target.branchName
+                    ).then(function() {
+                        return target;
+                    });
+                })
+                .then(function(target) {
+                    showStatus('Creating pull request...', 'info');
+                    return createPR(token, 'feat: add photo ' + target.folderName, target.branchName, BRANCH);
+                })
+                .then(function(pr) {
+                    return enableAutoMerge(token, pr.node_id).then(function() {
+                        return pr;
+                    });
+                })
                     .then(function(pr) {
                         statusEl.innerHTML = 'Photo uploaded! <a href="' + pr.html_url + '" target="_blank" rel="noopener">View PR</a> — it will auto-merge after the build passes.';
                         statusEl.className = 'status success';
-                        photoInput.value = '';
-                        previewEl.classList.remove('visible');
-                        aiSection.style.display = 'none';
-                        window._sharedPhoto = null;
-                        currentPhotoFile = null;
-                        aiFeedback.value = '';
-                        aiTitle.value = '';
-                        aiAlt.value = '';
-                        aiDesc.value = '';
+                        clearUploadForm();
                     })
                     .catch(function(err) {
                         showStatus('Upload failed: ' + err.message, 'error');
@@ -639,10 +742,12 @@
                     .finally(function() {
                         submitBtn.disabled = false;
                     });
-            };
-            reader.readAsDataURL(file);
-        });
+        };
+        reader.readAsDataURL(file);
     });
+
+    publishDateInput.max = getSiteLocalDateString(new Date());
+    publishDateInput.dataset.source = 'manual';
 
     // --- Initialize ---
     handleOAuthCallback().then(function(justLoggedIn) {

--- a/static/upload/index.html
+++ b/static/upload/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="preload" as="font" href="/fonts/roboto-slab-latin.woff2" type="font/woff2" crossorigin>
-    <link rel="stylesheet" href="/upload/style.css?v=10">
+    <link rel="stylesheet" href="/upload/style.css?v=11">
 </head>
 <body>
     <h1>Photo Upload</h1>
@@ -42,6 +42,11 @@
                     <input type="text" id="ai-title" class="ai-value ai-input" placeholder="Add a short title" spellcheck="true">
                 </div>
                 <div class="ai-field">
+                    <label class="ai-label" for="publish-date">Publish date</label>
+                    <input type="date" id="publish-date" class="ai-value ai-input">
+                    <p id="publish-date-status" class="field-help">Publish date uses America/New_York. Future dates are rejected because Cloudflare Pages does not auto-publish at midnight.</p>
+                </div>
+                <div class="ai-field">
                     <label class="ai-label" for="ai-alt">Alt text</label>
                     <textarea id="ai-alt" class="ai-value" rows="2" placeholder="Describe what is visible for screen readers" spellcheck="true"></textarea>
                 </div>
@@ -61,6 +66,6 @@
         </div>
     </div>
 
-    <script src="/upload/app.js?v=10"></script>
+    <script src="/upload/app.js?v=11"></script>
 </body>
 </html>

--- a/static/upload/style.css
+++ b/static/upload/style.css
@@ -128,6 +128,11 @@ h1 {
     font-size: 0.9rem;
 }
 
+.field-help {
+    font-size: 0.85rem;
+    color: #666;
+}
+
 .preview {
     margin-bottom: 1.5rem;
     display: none;
@@ -221,6 +226,11 @@ textarea.ai-value:focus {
     border-color: #999;
 }
 
+input.ai-value.invalid,
+textarea.ai-value.invalid {
+    border-color: #b94a48;
+}
+
 input.ai-value::placeholder,
 textarea.ai-value::placeholder {
     color: #8a8a8a;
@@ -259,4 +269,16 @@ textarea.ai-value {
 .ai-feedback .btn {
     font-size: 0.85rem;
     padding: 0.4rem 0.8rem;
+}
+
+#publish-date-status {
+    margin-top: 0.25rem;
+}
+
+#publish-date-status.error {
+    color: #922b21;
+}
+
+#publish-date-status.info {
+    color: #555;
 }


### PR DESCRIPTION
## Summary
- Prevent photo uploads and manual content changes from silently disappearing after deploy when Hugo treats them as future content. The fix should make uploader dates explicit and site-timezone-aware, and it should make CI fail fast when `main` contains published pages that Cloudflare Pages will not render yet.

## Test plan
- [x] Uploading a photo without EXIF after 8 PM ET uses the ET calendar date, not the next UTC day
- [x] The upload UI surfaces the publish date and blocks submission when that date would be future content in the site timezone
- [x] `scripts/check-future-content.sh` passes for normal content and fails with a clear error for a temporary future-dated test page
- [ ] The next successful deploy includes the previously missed bonsai photo in `/photography/`
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] Site renders correctly on localhost (`hugo server -D`)

Generated with the repo-local Bash workflow
